### PR TITLE
Return Assertion ID

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -339,6 +339,14 @@ get_session_info = (dom, index_required=true) ->
 
   info
 
+get_assertion_id = (dom) ->
+  assertion = dom.getElementsByTagNameNS(XMLNS.SAML, 'Assertion')
+  throw new Error("Expected 1 Assertion; found #{assertion.length}") unless assertion.length is 1
+
+  assertion_id = get_attribute_value assertion[0], 'ID'
+
+  assertion_id
+
 # Takes in an xml @dom of an object containing a SAML Assertion and returns and object containing the attributes
 # contained within the Assertion. It will throw an error if the Assertion is missing or does not appear to be valid.
 parse_assertion_attributes = (dom) ->
@@ -495,6 +503,7 @@ parse_authn_response = (saml_response, sp_private_keys, idp_certificates, allow_
         session_info = get_session_info validated_assertion, require_session_index
         user.name_id = get_name_id validated_assertion
         user.session_index = session_info.index
+        user.assertion_id = get_assertion_id validated_assertion
         if session_info.not_on_or_after?
           user.session_not_on_or_after = session_info.not_on_or_after
 
@@ -752,3 +761,4 @@ if process.env.NODE_ENV is "test"
   module.exports.add_namespaces_to_child_assertions = add_namespaces_to_child_assertions
   module.exports.set_option_defaults = set_option_defaults
   module.exports.extract_certificate_data = extract_certificate_data
+  module.exports.get_assertion_id = get_assertion_id

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -266,6 +266,15 @@ describe 'saml2', ->
         name_id = saml2.get_name_id dom_from_test_file('good_assertion_explicit_namespaces.xml')
         assert.equal name_id, 'tstudent'
 
+    describe 'get_assertion_id', ->
+      it 'gets the correct assertionId', ->
+        assertion_id = saml2.get_assertion_id dom_from_test_file('good_assertion.xml')
+        assert.equal assertion_id, '_3'
+
+      it 'parses assertions with explicit namespaces', ->
+        assertion_id = saml2.get_assertion_id dom_from_test_file('good_assertion_explicit_namespaces.xml')
+        assert.equal assertion_id, '_3'
+
     describe 'get_session_info', ->
       it 'gets the correct session index', ->
         info = saml2.get_session_info dom_from_test_file('good_assertion.xml')
@@ -401,6 +410,7 @@ describe 'saml2', ->
           user:
             name_id: 'tstudent'
             session_index: '_3'
+            assertion_id: '_3'
             given_name: 'Test',
             email: 'tstudent@example.com',
             ppid: 'tstudent',
@@ -449,6 +459,7 @@ describe 'saml2', ->
           user:
             name_id: 'tstudent',
             session_index: '_3'
+            assertion_id: '_3'
             given_name: 'Test'
             attributes:
               'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': [ 'Test' ]
@@ -557,6 +568,7 @@ describe 'saml2', ->
           user:
             name_id: undefined
             session_index: '_4'
+            assertion_id: '_3'
             session_not_on_or_after: '2016-02-11T21:12:09Z'
             attributes: {}
 
@@ -628,6 +640,7 @@ describe 'saml2', ->
             user:
               name_id: undefined
               session_index: null
+              assertion_id: '_3'
               session_not_on_or_after: '2016-02-11T21:12:09Z'
               attributes: {}
 
@@ -998,6 +1011,7 @@ describe 'saml2', ->
           user:
             name_id: 'tstudent'
             session_index: '_3'
+            assertion_id: '_3'
             given_name: 'Test',
             email: 'tstudent@example.com',
             ppid: 'tstudent',


### PR DESCRIPTION
## Change

Adding logic to return assertion id during SAML binding.

## Problem / Why

Resolves https://github.com/Clever/saml2/issues/274

## References

- https://github.com/Clever/saml2/pull/273
